### PR TITLE
Added +tabs mixin implemented with jQuery

### DIFF
--- a/K_Scaffold/Template v2/scaffold/_htmlelements.pug
+++ b/K_Scaffold/Template v2/scaffold/_htmlelements.pug
@@ -11,8 +11,7 @@
         triggeredFuncs:['setActionCalls'],
         listenerFunc:'accessSheet',
         listener:'change:character_name'}
-      },
-    tabDetails:[],
+      }
   };
 - let selectName = null;
 - let selectTitle = null;
@@ -325,7 +324,7 @@ mixin p(obj)
     +button({name:'my button',value:'/r 3d10'})
     //An action button
     +button({name:'my button',type:'action','data-i18n':'action button',trigger:{triggeredFuncs:['doSomethingOnClick']}})
-mixin button(obj)
+mixin button(obj, _attributes)
   - obj.class = obj.class ? replaceProblems(obj.class) : undefined;
   - obj.name = replaceSpaces(obj.name);
   - obj.title = obj.title || buttonTitle(obj.name);
@@ -337,7 +336,7 @@ mixin button(obj)
   - const elementObj = makeElementObj(obj);
   if obj.type !== 'roll'
     - storeTrigger(obj);
-  button&attributes(elementObj)
+  button&attributes(elementObj)&attributes(attributes)
     block
 //-End Mixin
 //- @pugdoc
@@ -348,11 +347,11 @@ mixin button(obj)
   example: |
     include _htmlelements.pug
     +action({name:'my button','data-i18n':'action button',trigger:{triggeredFuncs:['doSomethingOnClick']}})
-mixin action(obj)
+mixin action(obj, _attributes)
   - obj.class = obj.class ? replaceProblems(obj.class) : undefined;
   - obj.type = 'action';
   - obj.name = obj.name.replace(/\s+/g,'-');
-  +button(obj)
+  +button(obj)&attributes(attributes)
     block
 //- End Mixin
 //- @pugdoc
@@ -366,7 +365,7 @@ mixin action(obj)
 mixin navButton(obj)
   - addIfUnique(obj.name,'navButtons');
   - obj.name = `nav ${obj.name}`;
-  +action(obj)
+  +action(obj)&attributes(attributes)
     block
 //- End Mixin
 mixin rollerExtras(obj)
@@ -816,7 +815,7 @@ mixin kscript
     |const k = (function(){
     |const kFuncs = {};
     //- The below declarations import variables from the pug file and mixins into the sheetworker code
-    - const propArray = ['cascades','repeatingSectionDetails','tabDetails'];
+    - const propArray = ['cascades','repeatingSectionDetails'];
     each prop in propArray
       |
       |const !{prop} = !{JSON.stringify(varObjects[prop])};

--- a/K_Scaffold/Template v2/scaffold/_htmlelements.pug
+++ b/K_Scaffold/Template v2/scaffold/_htmlelements.pug
@@ -1,4 +1,19 @@
-- const varObjects = {repeatingSectionDetails:[],actionAttributes:[],cascades:{attr_character_name:{name:'character_name',type:'text',defaultValue:'',affects:[],triggeredFuncs:['setActionCalls'],listenerFunc:'accessSheet',listener:'change:character_name'}}};
+-
+  const varObjects = {
+    repeatingSectionDetails:[],
+    actionAttributes:[],
+    cascades:{
+      attr_character_name:{
+        name:'character_name',
+        type:'text',
+        defaultValue:'',
+        affects:[],
+        triggeredFuncs:['setActionCalls'],
+        listenerFunc:'accessSheet',
+        listener:'change:character_name'}
+      },
+    tabDetails:[],
+  };
 - let selectName = null;
 - let selectTitle = null;
 - let repeatingPrefix = '';
@@ -772,6 +787,9 @@ mixin compendiumAttributes({prefix,lookupAttributes = ['Name','data'],triggerAcc
       - inputObj.trigger = trigger;
     +hidden(inputObj)
 //- End Mixin
+
+include tabs/tabs.pug
+
 //- Functions
 //- @pugdoc
   name: script
@@ -798,7 +816,7 @@ mixin kscript
     |const k = (function(){
     |const kFuncs = {};
     //- The below declarations import variables from the pug file and mixins into the sheetworker code
-    - const propArray = ['cascades','repeatingSectionDetails'];
+    - const propArray = ['cascades','repeatingSectionDetails','tabDetails'];
     each prop in propArray
       |
       |const !{prop} = !{JSON.stringify(varObjects[prop])};
@@ -814,6 +832,8 @@ mixin kscript
     include parse_cascade.js
     include sheetworker_aliases.js
     include listeners.js
+    include tabs/tabs.js
+    |
     |return kFuncs;
     |}());
     |

--- a/K_Scaffold/Template v2/scaffold/k.scss
+++ b/K_Scaffold/Template v2/scaffold/k.scss
@@ -1,0 +1,1 @@
+@use 'tabs/tabs.scss';

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.js
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.js
@@ -1,17 +1,12 @@
 
-(
-    function registerTabHandlers(storage) {
-        storage.forEach(
-            ({ name, tabs }) => {
-                kFuncs.log(`Registering handler for tab "${name}"`);
-                $20(`.tab.tab-${name} .tab-header.tab-header-${name} .tab-button.tab-button-${name}`).on("click", (event) => {
-                    const container_tab = event.htmlAttributes["data-container-tab"];
-                    const tab = event.htmlAttributes["data-tab"];
-                    kFuncs.log(`Clicked tab ${tab} in ${container_tab}`);
-                    $20(`.tab.tab-${name} div[data-tab]`).removeClass("active");
-                    $20(`.tab.tab-${name} div[data-tab=${tab}]`).addClass("active");
-                });
-            }
-        );
-    }
-)(tabDetails);
+const _kSwitchTab = function ({ trigger }) {
+    const [container, tab] = (
+        trigger.name.match(/nav-tabs-(.+)--(.+)/) ||
+        []
+    ).slice(1);
+    console.log([container, tab]);
+    $20(`[data-container-tab="${container}"]`).removeClass('k-active-tab');
+    $20(`[data-container-tab="${container}"][data-tab="${tab}"]`).addClass('k-active-tab');
+}
+
+registerFuncs({ _kSwitchTab });

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.js
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.js
@@ -1,0 +1,17 @@
+
+(
+    function registerTabHandlers(storage) {
+        storage.forEach(
+            ({ name, tabs }) => {
+                kFuncs.log(`Registering handler for tab "${name}"`);
+                $20(`.tab.tab-${name} .tab-header.tab-header-${name} .tab-button.tab-button-${name}`).on("click", (event) => {
+                    const container_tab = event.htmlAttributes["data-container-tab"];
+                    const tab = event.htmlAttributes["data-tab"];
+                    kFuncs.log(`Clicked tab ${tab} in ${container_tab}`);
+                    $20(`.tab.tab-${name} div[data-tab]`).removeClass("active");
+                    $20(`.tab.tab-${name} div[data-tab=${tab}]`).addClass("active");
+                });
+            }
+        );
+    }
+)(tabDetails);

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
@@ -13,44 +13,60 @@
             span Tab 1 content
         +tab("background")(class="tab_horizontal")
             span Tab background content
-mixin tabs(name="tabs")
+mixin tabs(name="tabs",defaultActiveTabIndex=0)
+    //- Cleanup the name to use "-" instead of spaces, and no problematic chars
+    //- We use "-" as in action buttons, because this name will be used in CSS classes
     - name = actionButtonName(replaceProblems(name));
 
+
+    //- Storage for all the tabs in this construct, plus a local mixin to pass
+    //- several pug blocks
     - const tabs = [];
     //- @pugdoc
       name: tab
       description: Mixin to add a new tab. Only available inside a {@link tabs} mixin. Attributes passed to the mixin are passed to the div containing the content, not to the header button.
       arguments:
       - {string} [name] - The name of the tab. Defaults to "tab" followed by a index count starting at 1 (so tab1, then tab2, ...)
-    mixin tab(name)
-        - name = actionButtonName(replaceProblems(name ? name : `tab${tabs.length + 1}`));
-        - tabs.push({name, attributes, block});
+    mixin tab(tabName,button={},container="div")
+        - tabName = actionButtonName(replaceProblems(tabName || `tab${tabs.length + 1}`));
+        - if (tabs.filter(tab => tab.name === tabName).length) { throw new Error(`Tab "${tabName}" already exists in "${name}".`); }
+        //- Cleanup the name of the navigation button
+        - button.name = `nav-tabs-${name}--${tabName}`;
+        //- Cleanup the class, add our own internal classes
+        - button.class = button.class ? replaceProblems(button.class) : "";
+        - button.class = `tabs__button tabs--${name}__button tabs--${name}__button--${tabName} ${button.class}`;
+        - button.class = button.class + (tabs.length === defaultActiveTabIndex ? " k-active-tab" : "");
+        //- If not provided, hook the button to the default tab switcher listener
+        - button.trigger = button.trigger || {triggeredFuncs:["_kSwitchTab"]};
+        //- Cleanup the class of the tab content passed through the implicit attributes
+        //- and add our own internal classes
+        - attributes.class = actionButtonName(replaceProblems(attributes.class || ""));
+        - attributes.class = `tabs__container tabs--${name}__container tabs--${name}__container--${tabName} ${attributes.class}`;
+        - attributes.class = attributes.class + (tabs.length === defaultActiveTabIndex ? " k-active-tab" : "");
+        //- Store the tab definition
+        - tabs.push({name:tabName, container, button, attributes, block});
     
-    - attributes.class = actionButtonName(replaceProblems(attributes.class ? attributes.class : ""));
-    - attributes.class = `tabs tabs--${name} ` + attributes.class;
+
+    //- Put everything in a global div with appropriate classes for CSS styling
+    //- and proper HTML organization
+    - attributes.class = actionButtonName(replaceProblems(attributes.class || ""));
+    - attributes.class = `tabs tabs--${name} ${attributes.class}`;
     div&attributes(attributes)
+        //- Execute the block passed to the +tabs mixin, if any
+        //- this fills the `tabs` array above when the +tab nested mixin
+        //- is called in the block
+        - block ? block() : undefined;
 
-        - block ? block() : undefined
-
-        div(class=`tabs__header tabs__header--${name}`)
+        //- Navigation header with action button to switch tabs
+        nav(class=`tabs__header tabs--${name}__header`)
             each tab, index in tabs
-                div(
-                    class=`tabs__button tabs__button--${name}` + (index === 0 ? " active" : "")
-                    data-container-tab=name
-                    data-tab=tab.name
-                )
-                    span(data-i18n=`tabs-${name}-${tab.name}`)
-                        != tab.name
+                +action(tab.button)(data-container-tab=name data-tab=tab.name data-i18n=`tabs-${name}-${tab.name}`)
+                    != tab.name
         
-        div(class=`tabs__body tabs__body--${name}`)
+        //- Global div storing all the tabs one after another
+        //- only one will be visible at the same time
+        div(class=`tabs__body tabs--${name}__body`)
             each tab, index in tabs
-                - tab.attributes.class = actionButtonName(replaceProblems(tab.attributes.class ? tab.attributes.class : ""));
-                - tab.attributes.class = `tabs__container tabs__container--${name} ` + (index === 0 ? "active " : "") + tab.attributes.class;
-                div(data-container-tab=name data-tab=tab.name)&attributes(tab.attributes)
+                - const container = tab.container;
+                #{container}(data-container-tab=name data-tab=tab.name)&attributes(tab.attributes)
                     - tab.block()
-    
-    -
-        varObjects["tabDetails"].push({
-            name,
-            tabs:tabs.map(data => { const {block, ...rest} = data; return rest; } )
-        });

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
@@ -4,15 +4,20 @@
   arguments:
     arguments:
     - {string} [name=tabs] - The name of the tabs construct. Used in all elements so that you may vary the styling of different tabs
+    - {integer} [name=defaultActiveTabIndex] - The name of the tabs construct. Used in all elements so that you may vary the styling of different tabs
   attributes:
   example: |
     include _htmlelements.pug
-    +tabs(name="sheet-tabs")(class="outer")
+    +tabs("sheet-tabs")(class="outer")
         span before the header
         +tab()(class="tab-vertical")
-            span Tab 1 content
+            span(style="background: white;") Tab 1 content
         +tab("background")(class="tab_horizontal")
-            span Tab background content
+            span(style="background: white;") Tab background content
+        +tab("history", {class:"custom-button", trigger:{}})(class="tab_horizontal")
+            span(style="background: white;") Tab history content
+        +tab("inventory", {}, "span")(class="tab_horizontal")
+            span(style="background: white;") Tab inventory content
 mixin tabs(name="tabs",defaultActiveTabIndex=0)
     //- Cleanup the name to use "-" instead of spaces, and no problematic chars
     //- We use "-" as in action buttons, because this name will be used in CSS classes
@@ -26,7 +31,9 @@ mixin tabs(name="tabs",defaultActiveTabIndex=0)
       name: tab
       description: Mixin to add a new tab. Only available inside a {@link tabs} mixin. Attributes passed to the mixin are passed to the div containing the content, not to the header button.
       arguments:
-      - {string} [name] - The name of the tab. Defaults to "tab" followed by a index count starting at 1 (so tab1, then tab2, ...)
+      - {string} [tabName] - The name of the tab. Defaults to "tab" followed by a index count starting at 1 (so tab1, then tab2, ...)
+      - {object} [button] - object passed to the +action mixin to build the action button for switching tabe. By default a trigger is defined, but you can override it.
+      - {string} [container] - tag to use to contain the whole tab. A div by default but can be overridden.
     mixin tab(tabName,button={},container="div")
         - tabName = actionButtonName(replaceProblems(tabName || `tab${tabs.length + 1}`));
         - if (tabs.filter(tab => tab.name === tabName).length) { throw new Error(`Tab "${tabName}" already exists in "${name}".`); }

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
@@ -1,0 +1,56 @@
+//- @pugdoc
+  name: tabs
+  description: A generic mixin to create tabs using jQuery. It uses a nested {@link tab} mixin to define tabs. Any content outside those mixin in put in the containing div, before the tabs. Attributes passed to the mixin are passed to the outer containing div.
+  arguments:
+    arguments:
+    - {string} [name=tabs] - The name of the tabs construct. Used in all elements so that you may vary the styling of different tabs
+  attributes:
+  example: |
+    include _htmlelements.pug
+    +tabs(name="sheet-tabs")(class="outer")
+        span before the header
+        +tab()(class="tab-vertical")
+            span Tab 1 content
+        +tab("background")(class="tab_horizontal")
+            span Tab background content
+mixin tabs(name="tabs")
+    - name = actionButtonName(replaceProblems(name));
+
+    - const tabs = [];
+    //- @pugdoc
+      name: tab
+      description: Mixin to add a new tab. Only available inside a {@link tabs} mixin. Attributes passed to the mixin are passed to the div containing the content, not to the header button.
+      arguments:
+      - {string} [name] - The name of the tab. Defaults to "tab" followed by a index count starting at 1 (so tab1, then tab2, ...)
+    mixin tab(name)
+        - name = actionButtonName(replaceProblems(name ? name : `tab${tabs.length + 1}`));
+        - tabs.push({name, attributes, block});
+    
+    - attributes.class = actionButtonName(replaceProblems(attributes.class ? attributes.class : ""));
+    - attributes.class = `tab tab-${name} ` + attributes.class;
+    div&attributes(attributes)
+
+        - block ? block() : undefined
+
+        div(class=`tab-header tab-header-${name}`)
+            each tab, index in tabs
+                div(
+                    class=`tab-button tab-button-${name}` + (index === 0 ? " active" : "")
+                    data-container-tab=name
+                    data-tab=tab.name
+                )
+                    span(data-i18n=`tab-${name}-${tab.name}`)
+                        != tab.name
+        
+        div(class=`tab-body tab-body-${name}`)
+            each tab, index in tabs
+                - tab.attributes.class = actionButtonName(replaceProblems(tab.attributes.class ? tab.attributes.class : ""));
+                - tab.attributes.class = `tab-container tab-container-${name} ` + (index === 0 ? "active " : "") + tab.attributes.class;
+                div(data-container-tab=name data-tab=tab.name)&attributes(tab.attributes)
+                    - tab.block()
+    
+    -
+        varObjects["tabDetails"].push({
+            name,
+            tabs:tabs.map(data => { const {block, ...rest} = data; return rest; } )
+        });

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.pug
@@ -27,25 +27,25 @@ mixin tabs(name="tabs")
         - tabs.push({name, attributes, block});
     
     - attributes.class = actionButtonName(replaceProblems(attributes.class ? attributes.class : ""));
-    - attributes.class = `tab tab-${name} ` + attributes.class;
+    - attributes.class = `tabs tabs--${name} ` + attributes.class;
     div&attributes(attributes)
 
         - block ? block() : undefined
 
-        div(class=`tab-header tab-header-${name}`)
+        div(class=`tabs__header tabs__header--${name}`)
             each tab, index in tabs
                 div(
-                    class=`tab-button tab-button-${name}` + (index === 0 ? " active" : "")
+                    class=`tabs__button tabs__button--${name}` + (index === 0 ? " active" : "")
                     data-container-tab=name
                     data-tab=tab.name
                 )
-                    span(data-i18n=`tab-${name}-${tab.name}`)
+                    span(data-i18n=`tabs-${name}-${tab.name}`)
                         != tab.name
         
-        div(class=`tab-body tab-body-${name}`)
+        div(class=`tabs__body tabs__body--${name}`)
             each tab, index in tabs
                 - tab.attributes.class = actionButtonName(replaceProblems(tab.attributes.class ? tab.attributes.class : ""));
-                - tab.attributes.class = `tab-container tab-container-${name} ` + (index === 0 ? "active " : "") + tab.attributes.class;
+                - tab.attributes.class = `tabs__container tabs__container--${name} ` + (index === 0 ? "active " : "") + tab.attributes.class;
                 div(data-container-tab=name data-tab=tab.name)&attributes(tab.attributes)
                     - tab.block()
     

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.scss
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.scss
@@ -1,0 +1,10 @@
+.tab {
+    .tab-body {
+        .tab-container {
+            display: none;
+        }
+        .tab-container.active {
+            display: block;
+        }
+    }
+}

--- a/K_Scaffold/Template v2/scaffold/tabs/tabs.scss
+++ b/K_Scaffold/Template v2/scaffold/tabs/tabs.scss
@@ -1,10 +1,7 @@
-.tab {
-    .tab-body {
-        .tab-container {
-            display: none;
-        }
-        .tab-container.active {
-            display: block;
+.tabs {
+    .tabs__body {
+        .tabs__container:not(.k-active-tab) {
+            display: none ! important;
         }
     }
 }


### PR DESCRIPTION
Here is amixin implementation of a tab selection, that use Roll20's jQuery implementation to change display.

## New Features
+ `+tabs(name="tabs")` mixin that makes it possible to add a tab selection using jQuery
    + a nested `+tab(name)` mixin, only available within `+tabs`, to add a tab to the tab selection
+ New k-scaffold data, exports and handlers to register the required jQuery callbacks
+ New `k.scss` user-facing file, that should be `@use`-ed in the user's sheet, to add the (minimal) SCSS needed for the above mixin to work out of the box. Only the bare minimum styling (hidden/visible) is provided.

The code are in dedicated files, because the `_htmlelements.pug` is getting big (>1000lines). I'll inline the code if you prefer, no problem.